### PR TITLE
Add instructions for manually granting calendar access in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,27 @@ Create or edit `~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 > ⚠️ **Critical**: Claude must be launched from the terminal to properly request calendar permissions. Launching directly from Finder will not trigger the permissions prompt.
 
+Run the following command in your terminal.
+
 ```bash
 /Applications/Claude.app/Contents/MacOS/Claude
 ```
 
-Alternatively, if you're willing to risk it, you can [manually grant Claude calendar access](https://lenticular.zone/macos-tcc-claude-mcp/). The following is tested on macOS 15.4 and requires full disk access for your terminal emulator.
+### Manually Grant Calendar Access
 
-> ⚠️ **Warning**: This changes your app permissions database on macOS.
+Alternatively, if you're willing to use an undocumented macOS feature, you can [manually grant Claude calendar access](https://lenticular.zone/macos-tcc-claude-mcp/). The following method has been tested on macOS 15.4 and requires full disk access for your terminal emulator.
+
+> ⚠️ **Warning**: This method modifies the TCC database directly, which is not recommended by Apple. Use at your own risk.
+
+> ⚠️ Modifying the TCC database directly can potentially cause system instability or security issues. This is an unofficial method that bypasses Apple's permission system, and future macOS updates may change how permissions work. Always back up your TCC database before making changes (as shown below), and proceed at your own risk. If something goes wrong, you may need to reset all TCC permissions or restore from backup.
 
 ```bash
+# Backup TCC database to your desktop
+# This is a critical step! Always backup your TCC database before making changes.
+cp ~/Library/Application\ Support/com.apple.TCC/TCC.db ~/Desktop/TCC_backup.db
+
+# Grant Calendar access to Claude
+# This command modifies the TCC database to allow access for the specified bundle identifier.
 sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db <<EOF
 REPLACE INTO access 
 VALUES(
@@ -175,6 +187,13 @@ EOF
 ```
 
 After allowing `com.anthropic.claudefordesktop` access to the Calendar service, you can reopen Claude.app as you normally would.
+
+If you want to revert the changes made to the TCC database, you can use macOS's built-in `tccutil` command to reset the Calendar permissions for Claude:
+
+```bash
+# Reset Calendar permissions for Claude
+tccutil reset Calendar com.anthropic.claudefordesktop
+```
 
 4. **Start Using!**
 ```

--- a/README.md
+++ b/README.md
@@ -147,53 +147,7 @@ Run the following command in your terminal.
 /Applications/Claude.app/Contents/MacOS/Claude
 ```
 
-### Manually Grant Calendar Access
-
-Alternatively, if you're willing to use an undocumented macOS feature, you can [manually grant Claude calendar access](https://lenticular.zone/macos-tcc-claude-mcp/). The following method has been tested on macOS 15.4 and requires full disk access for your terminal emulator.
-
-> ⚠️ **Warning**: This method modifies the TCC database directly, which is not recommended by Apple. Use at your own risk.
-
-> ⚠️ Modifying the TCC database directly can potentially cause system instability or security issues. This is an unofficial method that bypasses Apple's permission system, and future macOS updates may change how permissions work. Always back up your TCC database before making changes (as shown below), and proceed at your own risk. If something goes wrong, you may need to reset all TCC permissions or restore from backup.
-
-```bash
-# Backup TCC database to your desktop
-# This is a critical step! Always backup your TCC database before making changes.
-cp ~/Library/Application\ Support/com.apple.TCC/TCC.db ~/Desktop/TCC_backup.db
-
-# Grant Calendar access to Claude
-# This command modifies the TCC database to allow access for the specified bundle identifier.
-sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db <<EOF
-REPLACE INTO access 
-VALUES(
- 'kTCCServiceCalendar',
- 'com.anthropic.claudefordesktop',
- 0,
- 2,
- 2,
- 2,
- NULL,
- NULL,
- 0,
- 'UNUSED',
- NULL,
- 16,
- CAST(strftime('%s','now') AS INTEGER),
- NULL,
- NULL,
- 'UNUSED',
- 0
-);
-EOF
-```
-
-After allowing `com.anthropic.claudefordesktop` access to the Calendar service, you can reopen Claude.app as you normally would.
-
-If you want to revert the changes made to the TCC database, you can use macOS's built-in `tccutil` command to reset the Calendar permissions for Claude:
-
-```bash
-# Reset Calendar permissions for Claude
-tccutil reset Calendar com.anthropic.claudefordesktop
-```
+> ⚠️ **Warning**: Alternatively, you can [manually grant calendar access](docs/install.md#method-2-manually-grant-calendar-access), but this involves modifying system files and should only be done if you understand the risks involved.
 
 4. **Start Using!**
 ```

--- a/README.md
+++ b/README.md
@@ -145,6 +145,37 @@ Create or edit `~/Library/Application\ Support/Claude/claude_desktop_config.json
 /Applications/Claude.app/Contents/MacOS/Claude
 ```
 
+Alternatively, if you're willing to risk it, you can [manually grant Claude calendar access](https://lenticular.zone/macos-tcc-claude-mcp/). The following is tested on macOS 15.4 and requires full disk access for your terminal emulator.
+
+> ⚠️ **Warning**: This changes your app permissions database on macOS.
+
+```bash
+sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db <<EOF
+REPLACE INTO access 
+VALUES(
+ 'kTCCServiceCalendar',
+ 'com.anthropic.claudefordesktop',
+ 0,
+ 2,
+ 2,
+ 2,
+ NULL,
+ NULL,
+ 0,
+ 'UNUSED',
+ NULL,
+ 16,
+ CAST(strftime('%s','now') AS INTEGER),
+ NULL,
+ NULL,
+ 'UNUSED',
+ 0
+);
+EOF
+```
+
+After allowing `com.anthropic.claudefordesktop` access to the Calendar service, you can reopen Claude.app as you normally would.
+
 4. **Start Using!**
 ```
 Try: "What's my schedule looking like for next week?"

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Whilst this MCP server can be used with any MCP compatible client, the instructi
 1. **Clone and Setup**
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/mcp-ical.git
+git clone https://github.com/Omar-V2/mcp-ical.git
 cd mcp-ical
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Transform how you interact with your macOS calendar using natural language! The mcp-ical server leverages the Model Context Protocol (MCP) to turn your calendar management into a conversational experience.
 
-```
+```bash
 You: "What's my schedule for next week?"
 Claude: "Let me check that for you..."
 [Displays a clean overview of your upcoming week]
@@ -26,9 +26,10 @@ Claude: "✨ 📅 Created: Lunch with Sarah Tomorrow, 12:00 PM"
 ## ✨ Features
 
 ### 📅 Event Creation
+
 Transform natural language into calendar events instantly!
 
-```
+```text
 "Schedule a team lunch next Thursday at 1 PM at Bistro Garden"
 ↓
 📎 Created: Team Lunch
@@ -36,14 +37,16 @@ Transform natural language into calendar events instantly!
    📍 Bistro Garden
 ```
 
-#### Supported Features:
+#### Supported Features
+
 - Custom calendar selection
 - Location and notes
 - Smart reminders
 - Recurring events
 
-#### Power User Examples:
-```
+#### Power User Examples
+
+```text
 🔄 Recurring Events:
 "Set up my weekly team sync every Monday at 9 AM with a 15-minute reminder"
 
@@ -56,9 +59,10 @@ add notes about reviewing Q1 metrics, and remind me 1 hour before"
 ```
 
 ### 🔍 Smart Schedule Management & Availability
+
 Quick access to your schedule with natural queries:
 
-```
+```text
 "What's on my calendar for next week?"
 ↓
 📊 Shows your upcoming events with smart formatting
@@ -71,15 +75,17 @@ Quick access to your schedule with natural queries:
 ```
 
 ### ✏️ Intelligent Event Updates
+
 Modify events naturally:
 
-```
+```text
 Before: "Move tomorrow's team meeting to 3 PM instead"
 ↓
 After: ✨ Meeting rescheduled to 3:00 PM
 ```
 
-#### Update Capabilities:
+#### Update Capabilities
+
 - Time and date modifications
 - Calendar transfers
 - Location updates
@@ -88,73 +94,78 @@ After: ✨ Meeting rescheduled to 3:00 PM
 - Recurring pattern changes
 
 ### 📊 Calendar Management
+
 - View all available calendars
 - Smart calendar suggestions
 - Seamless Google Calendar integration when configured with iCloud
 
-> 💡 **Pro Tip**: Since you can create events in custom calendars, if you have your Google Calendar synced with you iCloud Calendar, you can use this MCP server to create events in your Google Calendar too! Just specify the google calendar when creating/updating events
+> 💡 **Pro Tip**: Since you can create events in custom calendars, if you have your Google Calendar synced with your iCloud Calendar, you can use this MCP server to create events in your Google Calendar too! Just specify the Google calendar when creating/updating events.
 
 ## 🚀 Quick Start
 
 > 💡 **Note**: While these instructions focus on setting up the MCP server with Claude for Desktop, this server can be used with any MCP-compatible client. For more details on using different clients, see [the MCP documentation](https://modelcontextprotocol.io/quickstart/client).
 
 ### Prerequisites
+
 - [uv package manager](https://github.com/astral-sh/uv)
 - macOS with Calendar app configured
-- An MCP client - [Claude for desktop](https://claude.ai/download) is recommend 
+- An MCP client - [Claude for desktop](https://claude.ai/download) is recommended
 
 ### Installation
 
 Whilst this MCP server can be used with any MCP compatible client, the instructions below are for use with Claude for desktop.
 
 1. **Clone and Setup**
-```bash
-# Clone the repository
-git clone https://github.com/Omar-V2/mcp-ical.git
-cd mcp-ical
 
-# Install dependencies
-uv sync
-```
+    ```bash
+    # Clone the repository
+    git clone https://github.com/Omar-V2/mcp-ical.git
+    cd mcp-ical
+
+    # Install dependencies
+    uv sync
+    ```
 
 2. **Configure Claude for Desktop**
 
-Create or edit `~/Library/Application\ Support/Claude/claude_desktop_config.json`:
+    Create or edit `~/Library/Application\ Support/Claude/claude_desktop_config.json`:
 
-```json
-{
-    "mcpServers": {
-        "mcp-ical": {
-            "command": "uv",
-            "args": [
-                "--directory",
-                "/ABSOLUTE/PATH/TO/PARENT/FOLDER/mcp-ical",
-                "run",
-                "mcp-ical"
-            ]
+    ```json
+    {
+        "mcpServers": {
+            "mcp-ical": {
+                "command": "uv",
+                "args": [
+                    "--directory",
+                    "/ABSOLUTE/PATH/TO/PARENT/FOLDER/mcp-ical",
+                    "run",
+                    "mcp-ical"
+                ]
+            }
         }
     }
-}
-```
+    ```
 
 3. **Launch Claude for Calendar Access**
 
-> ⚠️ **Critical**: Claude must be launched from the terminal to properly request calendar permissions. Launching directly from Finder will not trigger the permissions prompt.
+    > ⚠️ **Critical**: Claude must be launched from the terminal to properly request calendar permissions. Launching directly from Finder will not trigger the permissions prompt.
 
-Run the following command in your terminal.
+    Run the following command in your terminal.
 
-```bash
-/Applications/Claude.app/Contents/MacOS/Claude
-```
+    ```bash
+    /Applications/Claude.app/Contents/MacOS/Claude
+    ```
 
-> ⚠️ **Warning**: Alternatively, you can [manually grant calendar access](docs/install.md#method-2-manually-grant-calendar-access), but this involves modifying system files and should only be done if you understand the risks involved.
+    > ⚠️ **Warning**: Alternatively, you can [manually grant calendar access](docs/install.md#method-2-manually-grant-calendar-access), but this involves modifying system files and should only be done if you understand the risks involved.
 
 4. **Start Using!**
-```
-Try: "What's my schedule looking like for next week?"
-```
+
+    ```text
+    Try: "What's my schedule looking like for next week?"
+    ```
 
 > 🔑 **Note**: When you first use a calendar-related command, macOS will prompt for calendar access. This prompt will only appear if you launched Claude from the terminal as specified above.
+
 ## 🧪 Testing
 
 > ⚠️ **Warning**: Tests will create temporary calendars and events. While cleanup is automatic, only run tests in development environments.
@@ -170,20 +181,20 @@ uv run pytest tests
 ## 🐛 Known Issues
 
 ### Recurring Events
+
 - Non-standard recurring schedules may not always be set correctly
 - Better results with Claude 3.5 Sonnet compared to Haiku
 - Reminder timing for recurring all-day events may be off by one day
 
 ## 🤝 Contributing
 
-Feedback and contributions are welcomed! Here's how you can help:
+Feedback and contributions are welcome. Here's how you can help:
 
 1. Fork the repository
 2. Create your feature branch
 3. Commit your changes
 4. Push to the branch
 5. Open a Pull Request
-
 
 ## 📝 License
 
@@ -192,4 +203,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 🙏 Acknowledgments
 
 - Built with [Model Context Protocol](https://modelcontextprotocol.io)
-- MacOS Calendar integration built with [PyObjC](https://github.com/ronaldoussoren/pyobjc)
+- macOS Calendar integration built with [PyObjC](https://github.com/ronaldoussoren/pyobjc)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,106 @@
+# MCP iCal Server Installation Guide
+
+## Quick Installation
+
+1. **Clone and Setup**
+
+    ```bash
+    # Clone the repository
+    git clone https://github.com/Omar-V2/mcp-ical.git
+    cd mcp-ical
+
+    # Install dependencies
+    uv sync
+    ```
+
+2. **Configure Claude for Desktop**
+
+    Create or edit `~/Library/Application\ Support/Claude/claude_desktop_config.json`:
+
+    ```json
+    {
+        "mcpServers": {
+            "mcp-ical": {
+                "command": "uv"
+                "args": [
+                    "--directory"
+                    "/ABSOLUTE/PATH/TO/PARENT/FOLDER/mcp-ical"
+                    "run"
+                    "mcp-ical"
+                ]
+            }
+        }
+    }
+    ```
+
+## Calendar Access Configuration
+
+MacOS Calendar Service access is required for the MCP iCal server to function properly. Follow one of the methods below to grant calendar access to your Terminal app or to Claude.
+
+### Method 1: Launch Claude from Terminal (Recommended)
+
+> ⚠️ **Critical**: Claude must be launched from the terminal to properly request calendar permissions. Launching directly from Finder will not trigger the permissions prompt.
+
+Run the following command in your terminal:
+
+```bash
+/Applications/Claude.app/Contents/MacOS/Claude
+```
+
+When you first use a calendar-related command, macOS will prompt for calendar access. This prompt will only appear if you launched Claude from the terminal as specified above.
+
+### Method 2: Manually Grant Calendar Access
+
+> ⚠️ **WARNING**: This method modifies the TCC database directly, which is not recommended by Apple. Use at your own risk.
+>
+> ⚠️ **CRITICAL WARNING**: Modifying the TCC database directly can potentially cause system instability or security issues. This is an unofficial method that bypasses Apple's permission system, and future macOS updates may change how permissions work. Always back up your TCC database before making changes (as shown below) and proceed at your own risk. If something goes wrong, you may need to reset all TCC permissions or restore from a backup.
+
+This method has been tested on macOS 15.4 and requires full-disk access for your terminal emulator.
+
+```bash
+# Backup TCC database to your desktop
+# This is a critical step! Always backup your TCC database before making changes.
+cp ~/Library/Application\ Support/com.apple.TCC/TCC.db ~/Desktop/TCC_backup.db
+
+# Grant Calendar access to Claude
+# This command modifies the TCC database to allow access for the specified bundle identifier.
+sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db <<EOF
+REPLACE INTO access
+VALUES(
+    'kTCCServiceCalendar',
+    'com.anthropic.claudefordesktop',
+    0,
+    2,
+    2,
+    2,
+    NULL,
+    NULL,
+    0,
+    'UNUSED',
+    NULL,
+    16,
+    CAST(strftime('%s''now') AS INTEGER),
+    NULL,
+    NULL,
+    'UNUSED',
+    0
+);
+EOF
+```
+
+After allowing `com.anthropic.claudefordesktop` access to the Calendar service, you can reopen Claude.app as you normally would.
+
+### Reverting Calendar Permissions
+
+If you want to revert the changes you made to the TCC database, you can use macOS's built-in `tccutil` command to reset the Calendar permissions for Claude:
+
+```bash
+# Reset Calendar permissions for Claude
+tccutil reset Calendar com.anthropic.claudefordesktop
+```
+
+## Usage
+
+Once installed and configured with proper calendar access, you can start using the MCP iCal server:
+
+Try: `What's my schedule looking like for next week?`

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@
 
 ## Calendar Access Configuration
 
-MacOS Calendar Service access is required for the MCP iCal server to function properly. Follow one of the methods below to grant calendar access to your Terminal app or to Claude.
+macOS Calendar Service access is required for the MCP iCal server to function properly. Follow one of the methods below to grant calendar access to your Terminal app or to Claude.
 
 ### Method 1: Launch Claude from Terminal (Recommended)
 


### PR DESCRIPTION
This adds instructions for adding Claude.app to the TCC database with Calendar access.

If you want to remove the link, you're welcome to copy the content to your docs.