### PR TITLE
Add robust recurring event deletion with timezone-aware occurrence matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ wheels/
 # Virtual environments
 .venv
 .vscode
-.DS_Store
+.DS_Store.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "mcp-ical": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/Users/tamm/dev/mcp-ical",
+        "run",
+        "mcp-ical"
+      ]
+    }
+  }
+}

--- a/TIMEZONE_FIX_PLAN.md
+++ b/TIMEZONE_FIX_PLAN.md
@@ -1,0 +1,85 @@
+# Comprehensive Timezone Handling Fix Plan
+
+## Problem Summary
+
+Based on issues #5 and #17 from upstream, and our own testing, there are multiple timezone-related problems:
+
+1. **Model Layer Issue**: `convert_datetime()` creates naive datetime objects (no timezone)
+2. **Display Issue**: Event strings don't show timezone information
+3. **EventKit Incompatibility**: EventKit expects naive datetimes in local time, but we need to track timezone info
+4. **Cross-timezone Matching**: When Claude provides datetimes in different timezones, occurrence matching fails
+5. **Ambiguous Inputs**: Claude might send naive datetimes (which could be local time OR UTC)
+
+## Core Principles
+
+1. **Internal Representation**: All datetimes should be timezone-aware throughout our code
+2. **EventKit Boundary**: Convert to naive local time only when calling EventKit APIs
+3. **Be Kind to Claude**: Accept both naive (assume local time, fallback to UTC) and timezone-aware inputs
+4. **Never Guess Wrong**: Better to fail explicitly than silently match the wrong occurrence
+
+## Layer-by-Layer Approach
+
+### Layer 1: Event Model (models.py)
+**Goal**: Ensure all Event objects contain timezone-aware datetimes
+
+**Changes needed**:
+- `convert_datetime()`: Convert NSDate to timezone-aware datetime in local timezone
+  ```python
+  # Before: datetime.fromtimestamp(timestamp)  # naive
+  # After:  datetime.fromtimestamp(timestamp, tz=timezone.utc).astimezone()  # aware in local tz
+  ```
+- Apply to: `start_time`, `end_time`, `last_modified`, `recurrence_rule.end_date`
+- Update `__str__` to include timezone abbreviations for clarity
+
+### Layer 2: CalendarManager Input Handling (ical.py)
+**Goal**: Accept both naive and timezone-aware inputs from Claude, handle gracefully
+
+**Changes needed**:
+- `list_events()`: Accept timezone-aware `start_time`/`end_time`, convert to naive local for EventKit
+- `create_event()`: Accept timezone-aware datetimes in request, convert to naive local for EventKit
+- `update_event()`: Same as create_event
+- Helper function: `to_eventkit_datetime(dt)` - converts aware→naive local, passes through naive
+
+### Layer 3: Occurrence Matching (ical.py)
+**Goal**: Match occurrences correctly even when Claude uses different timezone representations
+
+**Changes needed**:
+- `find_event_occurrence()`: Try matching in multiple ways:
+  1. If timezone-aware: convert to local time for matching
+  2. If naive: try as-is first, then try UTC interpretation
+- `_search_occurrence_by_datetime()`: Convert all datetimes to naive local before EventKit predicate
+- Use exact datetime equality after timezone normalization
+
+### Layer 4: MCP Server Documentation (server.py)
+**Goal**: Guide Claude on how to provide datetimes
+
+**Updates needed**:
+- Clarify that timezone-aware datetimes are preferred
+- Document that naive datetimes are assumed to be local time (with UTC fallback)
+- Update examples to show both formats work
+- Remove conflicting guidance about timezone suffixes
+
+### Layer 5: Testing
+**Scenarios to cover**:
+- Create event with timezone-aware datetime ✓
+- Create event with naive datetime (local) ✓
+- Update single occurrence with timezone-aware datetime ✓
+- Update single occurrence with naive datetime ✓
+- Cross-timezone matching (PST event, query from AEDT) ✓
+- List events across timezone boundaries ✓
+- Display events with timezone information ✓
+
+## Implementation Order
+
+1. **Commit 1**: Fix `convert_datetime()` in models.py (foundational)
+2. **Commit 2**: Add `to_eventkit_datetime()` helper and use in CalendarManager
+3. **Commit 3**: Fix occurrence matching with timezone normalization
+4. **Commit 4**: Update MCP documentation to reflect new behavior
+5. **Commit 5**: Add/update tests for all scenarios
+
+## Key Decisions
+
+- **Timezone-aware everywhere internally**: More explicit, prevents bugs
+- **EventKit boundary conversion**: Only convert to naive at the last moment
+- **Graceful fallback**: Try local interpretation first, then UTC for naive datetimes
+- **Never fail silently**: If we can't find an occurrence, raise clear error

--- a/src/mcp_ical/ical.py
+++ b/src/mcp_ical/ical.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from threading import Semaphore
 from typing import Any
@@ -65,85 +66,121 @@ def to_eventkit_datetime(dt: datetime) -> datetime:
     return dt
 
 
-def add_attendees_via_applescript(event_id: str, attendee_emails: list[str], event_title: str) -> None:
+_calendar_app_last_launch: float = 0.0
+_CALENDAR_APP_COOLDOWN = 30  # seconds
+
+
+def _ensure_calendar_app():
+    """Launch Calendar.app if it hasn't been launched in the last 30 seconds."""
+    global _calendar_app_last_launch
+    now = time.monotonic()
+    if now - _calendar_app_last_launch > _CALENDAR_APP_COOLDOWN:
+        subprocess.run(["open", "-g", "-a", "Calendar"], check=False, timeout=5)
+        _calendar_app_last_launch = now
+
+
+def add_attendees_via_applescript(
+    attendee_emails: list[str],
+    event_title: str,
+    calendar_name: str,
+    start_date: datetime,
+) -> None:
     """Add attendees to an existing calendar event using AppleScript.
 
     EventKit's attendees property is read-only, but macOS Calendar.app's AppleScript
     interface supports adding attendees. This function uses AppleScript to add
-    attendees to an already-created event.
+    attendees to an already-created event, matching by calendar + title + start date.
 
     Args:
-        event_id: The EventKit identifier of the event (from event.eventIdentifier())
         attendee_emails: List of email addresses (can be "Name <email@example.com>" format)
-        event_title: The title/summary of the event (used for finding the event)
-
-    Raises:
-        Exception: If AppleScript execution fails
+        event_title: The title/summary of the event
+        calendar_name: The calendar the event belongs to
+        start_date: The start date of the event (naive local time, as from EventKit)
     """
     if not attendee_emails:
         return
 
-    import time
-
-    # Give Calendar.app a moment to sync with EventKit
-    # Also launch Calendar.app to ensure it's running
-    try:
-        subprocess.run(["open", "-a", "Calendar"], check=False, timeout=5)
-        time.sleep(2)  # Give it more time to sync
-    except Exception:
-        pass
+    # Ensure Calendar.app is running (rate-limited to avoid crash-inducing rapid launches).
+    # Google CalDAV calendars need ~8s for Calendar.app to pick up EventKit changes.
+    _ensure_calendar_app()
+    time.sleep(8)
 
     # Build list of attendees for AppleScript
     attendees_data = []
     for email_str in attendee_emails:
-        # Parse email - support both "email@example.com" and "Name <email@example.com>" formats
         email_str = email_str.strip()
-
         if "<" in email_str and ">" in email_str:
-            # Extract name and email from "Name <email@example.com>" format
             parts = email_str.split("<")
-            name = parts[0].strip().replace('"', '\\"')  # Escape quotes
+            name = parts[0].strip().replace('"', '\\"')
             email = parts[1].replace(">", "").strip()
         else:
             email = email_str
             name = email.split("@")[0] if "@" in email else email
-
         attendees_data.append((name, email))
 
-    # Escape the event title for AppleScript
     escaped_title = event_title.replace('"', '\\"')
+    escaped_calendar = calendar_name.replace('"', '\\"')
 
-    # AppleScript to add all attendees to the event
-    # Search across all calendars for the event by summary
     attendees_list = ", ".join(
         [f'{{email:"{email}", display name:"{name}"}}' for name, email in attendees_data]
     )
 
+    # Convert start_date to a Python datetime for AppleScript date components.
+    # EventKit returns NSDate objects, so handle both NSDate and Python datetime.
+    if hasattr(start_date, "timeIntervalSince1970"):
+        # NSDate — convert to naive local datetime
+        timestamp = start_date.timeIntervalSince1970()
+        start_date = datetime.fromtimestamp(timestamp)
+    elif hasattr(start_date, "tzinfo") and start_date.tzinfo is not None:
+        start_date = start_date.astimezone().replace(tzinfo=None)
+
     applescript = f'''
     tell application "Calendar"
-        set allCalendars to every calendar
+        set targetDate to current date
+        set year of targetDate to {start_date.year}
+        set month of targetDate to {start_date.month}
+        set day of targetDate to {start_date.day}
+        set hours of targetDate to {start_date.hour}
+        set minutes of targetDate to {start_date.minute}
+        set seconds of targetDate to {start_date.second}
+
+        -- Step 1: Find the event (retry if Calendar.app hasn't synced it yet)
+        set maxFindAttempts to 5
         set foundEvent to missing value
 
-        repeat with cal in allCalendars
+        repeat maxFindAttempts times
             try
-                set matchingEvents to (every event of cal whose summary is "{escaped_title}")
+                set cal to first calendar whose name is "{escaped_calendar}"
+                set matchingEvents to (every event of cal whose summary is "{escaped_title}" and start date is targetDate)
                 if (count of matchingEvents) > 0 then
                     set foundEvent to item 1 of matchingEvents
                     exit repeat
                 end if
             end try
+            delay 2
         end repeat
 
-        if foundEvent is not missing value then
-            tell foundEvent
-                repeat with attendeeData in {{{attendees_list}}}
-                    make new attendee with properties attendeeData
-                end repeat
-            end tell
-            return "success"
-        else
-            error "Event not found in any calendar"
+        if foundEvent is missing value then
+            error "Event not found after " & maxFindAttempts & " attempts for \\"{escaped_title}\\" in \\"{escaped_calendar}\\""
         end if
+
+        -- Step 2: Add attendees (once only)
+        tell foundEvent
+            repeat with attendeeData in {{{attendees_list}}}
+                make new attendee with properties attendeeData
+            end repeat
+        end tell
+
+        -- Step 3: Verify attendees persisted (retry read, not write)
+        set maxVerifyAttempts to 3
+        repeat maxVerifyAttempts times
+            delay 2
+            if (count of (every attendee of foundEvent)) > 0 then
+                return "success"
+            end if
+        end repeat
+
+        error "Attendees added but did not persist for \\"{escaped_title}\\" in \\"{escaped_calendar}\\""
     end tell
     '''
 
@@ -152,12 +189,10 @@ def add_attendees_via_applescript(event_id: str, attendee_emails: list[str], eve
             ["osascript", "-e", applescript],
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=30,
         )
         if result.returncode != 0:
-            logger.warning(
-                f"Failed to add attendees via AppleScript: {result.stderr}"
-            )
+            logger.warning(f"Failed to add attendees via AppleScript: {result.stderr}")
         else:
             logger.info(f"Successfully added {len(attendee_emails)} attendee(s) via AppleScript")
     except Exception as e:
@@ -279,11 +314,15 @@ class CalendarManager:
             if new_event.attendees:
                 try:
                     add_attendees_via_applescript(
-                        ekevent.eventIdentifier(), new_event.attendees, new_event.title
+                        attendee_emails=new_event.attendees,
+                        event_title=new_event.title,
+                        calendar_name=ekevent.calendar().title(),
+                        start_date=ekevent.startDate(),
                     )
+                    # Refresh store so the returned Event includes attendees
+                    self.event_store.refreshSourcesIfNecessary()
                 except Exception as e:
                     logger.warning(f"Failed to add attendees via AppleScript: {e}")
-                    # Don't fail the entire event creation if attendees fail
 
             return Event.from_ekevent(ekevent)
 
@@ -396,13 +435,16 @@ class CalendarManager:
             # AppleScript interface does
             if request.attendees is not None:
                 try:
-                    # Get the event title (use updated title if provided, otherwise existing)
-                    event_title = request.title if request.title else existing_event.title
-                    event_uid = existing_ek_event.eventIdentifier()
-                    add_attendees_via_applescript(event_uid, request.attendees, event_title)
+                    add_attendees_via_applescript(
+                        attendee_emails=request.attendees,
+                        event_title=request.title if request.title else existing_event.title,
+                        calendar_name=existing_ek_event.calendar().title(),
+                        start_date=existing_ek_event.startDate(),
+                    )
+                    # Refresh store so the returned Event includes attendees
+                    self.event_store.refreshSourcesIfNecessary()
                 except Exception as e:
                     logger.warning(f"Failed to update attendees via AppleScript: {e}")
-                    # Don't fail the entire update if attendees fail
 
             # Build log message based on what was updated
             if occurrence_date and update_future_events:

--- a/src/mcp_ical/ical.py
+++ b/src/mcp_ical/ical.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from threading import Semaphore
@@ -62,6 +63,105 @@ def to_eventkit_datetime(dt: datetime) -> datetime:
         return dt.astimezone().replace(tzinfo=None)
     # Naive: pass through as-is (assume it's already local time)
     return dt
+
+
+def add_attendees_via_applescript(event_id: str, attendee_emails: list[str], event_title: str) -> None:
+    """Add attendees to an existing calendar event using AppleScript.
+
+    EventKit's attendees property is read-only, but macOS Calendar.app's AppleScript
+    interface supports adding attendees. This function uses AppleScript to add
+    attendees to an already-created event.
+
+    Args:
+        event_id: The EventKit identifier of the event (from event.eventIdentifier())
+        attendee_emails: List of email addresses (can be "Name <email@example.com>" format)
+        event_title: The title/summary of the event (used for finding the event)
+
+    Raises:
+        Exception: If AppleScript execution fails
+    """
+    if not attendee_emails:
+        return
+
+    import time
+
+    # Give Calendar.app a moment to sync with EventKit
+    # Also launch Calendar.app to ensure it's running
+    try:
+        subprocess.run(["open", "-a", "Calendar"], check=False, timeout=5)
+        time.sleep(2)  # Give it more time to sync
+    except Exception:
+        pass
+
+    # Build list of attendees for AppleScript
+    attendees_data = []
+    for email_str in attendee_emails:
+        # Parse email - support both "email@example.com" and "Name <email@example.com>" formats
+        email_str = email_str.strip()
+
+        if "<" in email_str and ">" in email_str:
+            # Extract name and email from "Name <email@example.com>" format
+            parts = email_str.split("<")
+            name = parts[0].strip().replace('"', '\\"')  # Escape quotes
+            email = parts[1].replace(">", "").strip()
+        else:
+            email = email_str
+            name = email.split("@")[0] if "@" in email else email
+
+        attendees_data.append((name, email))
+
+    # Escape the event title for AppleScript
+    escaped_title = event_title.replace('"', '\\"')
+
+    # AppleScript to add all attendees to the event
+    # Search across all calendars for the event by summary
+    attendees_list = ", ".join(
+        [f'{{email:"{email}", display name:"{name}"}}' for name, email in attendees_data]
+    )
+
+    applescript = f'''
+    tell application "Calendar"
+        set allCalendars to every calendar
+        set foundEvent to missing value
+
+        repeat with cal in allCalendars
+            try
+                set matchingEvents to (every event of cal whose summary is "{escaped_title}")
+                if (count of matchingEvents) > 0 then
+                    set foundEvent to item 1 of matchingEvents
+                    exit repeat
+                end if
+            end try
+        end repeat
+
+        if foundEvent is not missing value then
+            tell foundEvent
+                repeat with attendeeData in {{{attendees_list}}}
+                    make new attendee with properties attendeeData
+                end repeat
+            end tell
+            return "success"
+        else
+            error "Event not found in any calendar"
+        end if
+    end tell
+    '''
+
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", applescript],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                f"Failed to add attendees via AppleScript: {result.stderr}"
+            )
+        else:
+            logger.info(f"Successfully added {len(attendee_emails)} attendee(s) via AppleScript")
+    except Exception as e:
+        logger.warning(f"Exception adding attendees via AppleScript: {e}")
 
 
 class CalendarManager:
@@ -172,6 +272,19 @@ class CalendarManager:
                 raise Exception(error)
 
             logger.info(f"Successfully created event: {new_event.title}")
+
+            # Add attendees via AppleScript after event is saved
+            # EventKit doesn't support adding attendees programmatically, but Calendar.app's
+            # AppleScript interface does
+            if new_event.attendees:
+                try:
+                    add_attendees_via_applescript(
+                        ekevent.eventIdentifier(), new_event.attendees, new_event.title
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to add attendees via AppleScript: {e}")
+                    # Don't fail the entire event creation if attendees fail
+
             return Event.from_ekevent(ekevent)
 
         except Exception as e:
@@ -277,6 +390,19 @@ class CalendarManager:
             if not success:
                 logger.error(f"Failed to update event: {error}")
                 raise Exception(error)
+
+            # Update attendees via AppleScript after event is saved
+            # EventKit doesn't support modifying attendees programmatically, but Calendar.app's
+            # AppleScript interface does
+            if request.attendees is not None:
+                try:
+                    # Get the event title (use updated title if provided, otherwise existing)
+                    event_title = request.title if request.title else existing_event.title
+                    event_uid = existing_ek_event.eventIdentifier()
+                    add_attendees_via_applescript(event_uid, request.attendees, event_title)
+                except Exception as e:
+                    logger.warning(f"Failed to update attendees via AppleScript: {e}")
+                    # Don't fail the entire update if attendees fail
 
             # Build log message based on what was updated
             if occurrence_date and update_future_events:

--- a/src/mcp_ical/models.py
+++ b/src/mcp_ical/models.py
@@ -143,7 +143,18 @@ class Event:
     @classmethod
     def from_ekevent(cls, ekevent: EKEvent) -> "Event":
         """Create an Event instance from an EKEvent."""
-        attendees = [str(attendee.name()) for attendee in ekevent.attendees()] if ekevent.attendees() else []
+        attendees = []
+        if ekevent.attendees():
+            for attendee in ekevent.attendees():
+                name = str(attendee.name()) if attendee.name() else None
+                url = str(attendee.URL()) if attendee.URL() else None
+                email = url.replace("mailto:", "") if url and url.startswith("mailto:") else None
+                if name and email:
+                    attendees.append(f"{name} <{email}>")
+                elif email:
+                    attendees.append(email)
+                elif name:
+                    attendees.append(name)
 
         # Convert EKAlarms to our Alarm objects
         alarms = []

--- a/src/mcp_ical/models.py
+++ b/src/mcp_ical/models.py
@@ -242,17 +242,20 @@ class Event:
         if self.calendar_name:
             parts.append(f"  calendar: {self.calendar_name}")
 
-        # Location (truncated)
+        # Location — show short venue names, suppress long URLs
         if self.location:
-            loc = self.location if len(self.location) <= 80 else self.location[:77] + "..."
-            parts.append(f"  location: {loc}")
+            loc = self.location.strip()
+            if loc.startswith(("http://", "https://")):
+                parts.append("  location: (online meeting link)")
+            else:
+                if len(loc) > 80:
+                    loc = loc[:77] + "..."
+                parts.append(f"  location: {loc}")
 
-        # Notes — first 100 chars only
+        # Notes — just flag presence; content often contains URLs, email
+        # threads, legal boilerplate etc. that bloats the listing
         if self.notes:
-            note = self.notes.replace("\n", " ").strip()
-            if len(note) > 100:
-                note = note[:97] + "..."
-            parts.append(f"  notes: {note}")
+            parts.append("  has_notes: yes")
 
         # Attendee count (not the full list)
         if self.attendees:

--- a/src/mcp_ical/models.py
+++ b/src/mcp_ical/models.py
@@ -201,13 +201,21 @@ class Event:
         attendees_list = ", ".join(self.attendees) if self.attendees else "None"
         alarms_list = ", ".join(map(str, self.alarms_minutes_offsets)) if self.alarms_minutes_offsets else "None"
 
-        # Format datetime in ISO 8601 format with timezone offset
+        # Format datetime with BOTH ISO 8601 (for machine use) and human-readable local time.
+        # IMPORTANT FOR AI CONSUMERS: Always use the "Local time" field when displaying times
+        # to users or assigning events to calendar days. The ISO timestamp includes a UTC offset
+        # — do NOT read just the date portion without applying the offset first. The local time
+        # string is pre-converted and unambiguous.
         def format_dt(dt):
             if dt is None:
                 return "N/A"
-            # Use isoformat() for standard ISO 8601 representation with timezone
-            # e.g., "2025-11-14T14:00:00+11:00" or "2025-11-14T03:00:00-08:00"
-            return dt.isoformat()
+            iso = dt.isoformat()
+            # Human-readable in local timezone (%-d avoids leading zero on macOS/Linux)
+            try:
+                local = dt.astimezone().strftime("%-d %b %Y %A %-I:%M %p %Z")
+            except Exception:
+                local = iso
+            return f"{iso} (Local time: {local})"
 
         recurrence_info = "No recurrence"
         if self.recurrence_rule:
@@ -247,6 +255,7 @@ class CreateEventRequest(BaseModel):
     url: str | None = None
     all_day: bool = False
     recurrence_rule: RecurrenceRule | None = None
+    attendees: list[str] | None = None
 
 
 class UpdateEventRequest(BaseModel):
@@ -260,3 +269,4 @@ class UpdateEventRequest(BaseModel):
     url: str | None = None
     all_day: bool | None = None
     recurrence_rule: RecurrenceRule | None = None
+    attendees: list[str] | None = None

--- a/src/mcp_ical/models.py
+++ b/src/mcp_ical/models.py
@@ -207,25 +207,87 @@ class Event:
             _raw_event=ekevent,
         )
 
+    @staticmethod
+    def _format_local(dt: datetime) -> str:
+        """Format a datetime as a human-readable local time string."""
+        if dt is None:
+            return "N/A"
+        try:
+            return dt.astimezone().strftime("%-d %b %Y %A %-I:%M %p %Z")
+        except Exception:
+            return dt.isoformat()
+
+    def to_summary(self) -> str:
+        """Return a compact one-event summary for list_events output.
+
+        Includes only the fields an AI agent typically needs when scanning a
+        calendar. The consumer can call list_events with a narrow range or
+        inspect a single event by ID if they need full details.
+        """
+        parts: list[str] = []
+
+        # Title line with date
+        if self.all_day:
+            date_str = self.start_time.astimezone().strftime("%-d %b %Y %A")
+            parts.append(f"{self.title} (all day, {date_str})")
+        else:
+            start_local = self._format_local(self.start_time)
+            end_time_str = self.end_time.astimezone().strftime("%-I:%M %p") if self.end_time else ""
+            parts.append(f"{self.title}  {start_local} - {end_time_str}")
+
+        # ID — always needed for update/delete operations
+        parts.append(f"  id: {self.identifier}")
+
+        # Calendar
+        if self.calendar_name:
+            parts.append(f"  calendar: {self.calendar_name}")
+
+        # Location (truncated)
+        if self.location:
+            loc = self.location if len(self.location) <= 80 else self.location[:77] + "..."
+            parts.append(f"  location: {loc}")
+
+        # Notes — first 100 chars only
+        if self.notes:
+            note = self.notes.replace("\n", " ").strip()
+            if len(note) > 100:
+                note = note[:97] + "..."
+            parts.append(f"  notes: {note}")
+
+        # Attendee count (not the full list)
+        if self.attendees:
+            parts.append(f"  attendees: {len(self.attendees)}")
+
+        # Recurrence — human-readable summary
+        if self.recurrence_rule:
+            rr = self.recurrence_rule
+            freq = rr.frequency.name.lower()
+            summary = f"every {rr.interval} {freq}" if rr.interval > 1 else freq
+            if rr.occurrence_count:
+                summary += f", {rr.occurrence_count} times"
+            elif rr.end_date:
+                summary += f", until {self._format_local(rr.end_date)}"
+            parts.append(f"  recurrence: {summary}")
+
+        # Status: flag cancelled events
+        if self.status == 3:
+            parts.append("  status: CANCELLED")
+
+        return "\n".join(parts)
+
     def __str__(self) -> str:
-        """Return a human-readable string representation of the Event."""
+        """Return a detailed string representation of the Event.
+
+        Used when inspecting a single event. For list output, use to_summary().
+        """
         attendees_list = ", ".join(self.attendees) if self.attendees else "None"
         alarms_list = ", ".join(map(str, self.alarms_minutes_offsets)) if self.alarms_minutes_offsets else "None"
 
-        # Format datetime with BOTH ISO 8601 (for machine use) and human-readable local time.
-        # IMPORTANT FOR AI CONSUMERS: Always use the "Local time" field when displaying times
-        # to users or assigning events to calendar days. The ISO timestamp includes a UTC offset
-        # — do NOT read just the date portion without applying the offset first. The local time
-        # string is pre-converted and unambiguous.
         def format_dt(dt):
             if dt is None:
                 return "N/A"
             iso = dt.isoformat()
-            # Human-readable in local timezone (%-d avoids leading zero on macOS/Linux)
-            try:
-                local = dt.astimezone().strftime("%-d %b %Y %A %-I:%M %p %Z")
-            except Exception:
-                local = iso
+            local = self._format_local(dt)
             return f"{iso} (Local time: {local})"
 
         recurrence_info = "No recurrence"

--- a/src/mcp_ical/server.py
+++ b/src/mcp_ical/server.py
@@ -259,13 +259,8 @@ async def delete_event(
 ) -> str:
     """Delete a calendar event or specific occurrence(s) of a recurring event.
 
-    IMPORTANT: For best results, use the EXACT datetime from list_events when deleting specific
-    occurrences. The system now fully supports timezone-aware datetimes in ISO 8601 format
-    and will automatically handle timezone conversions.
-
-    Datetime formats supported:
-    - Timezone-aware (preferred): "2025-11-15T09:00:00+11:00" or "2025-11-15T09:00:00-08:00"
-    - Naive (local timezone assumed): "2025-11-15T09:00:00"
+    IMPORTANT: When deleting specific occurrences, the system supports BOTH timezone-aware and
+    timezone-naive datetime formats. You can use the datetime string exactly as returned by list_events.
 
     Before using this tool, make sure to:
     1. Confirm with the user that they want to delete this event
@@ -276,32 +271,26 @@ async def delete_event(
             - Delete the entire series: set delete_entire_series=True (no occurrence_date)
         - Ask which occurrence(s) they want to delete if that isn't very clear
         - Use list_events first to get exact datetimes if you don't have them
-        - Copy the EXACT datetime from list_events output
+        - Copy the datetime from list_events output
 
     Args:
         event_id: Unique identifier of the event (master event ID for recurring events)
         delete_entire_series: When True with occurrence_date, deletes that occurrence and all future ones.
                              When True without occurrence_date, deletes all occurrences.
                              When False (default), deletes only the specific occurrence.
-        occurrence_date: The EXACT start time from list_events output.
+        occurrence_date: The start time from list_events output.
                         REQUIRED when deleting a specific occurrence.
-                        Supports both timezone-aware and naive datetime formats:
-                        - With timezone (preferred): "2025-11-23T14:00:00+11:00"
-                        - Without timezone: "2025-11-23T14:00:00" (assumes local time)
-                        Always copy exactly from list_events output for best results.
+                        Both formats work:
+                        - "2025-11-23T14:00:00+11:00" (with timezone)
+                        - "2025-11-23T14:00:00" (without timezone - assumes local)
 
     Usage Examples:
         - Delete non-recurring event: delete_event("event-id-123")
         - Delete one occurrence:
-          1. First: list_events to get exact datetime
+          1. First: list_events to get datetime
           2. Then: delete_event("event-id-456", occurrence_date="2025-11-23T14:00:00+11:00")
         - Delete from occurrence forward: delete_event("event-id-456", occurrence_date="2025-11-23T14:00:00+11:00", delete_entire_series=True)
         - Delete all occurrences: delete_event("event-id-456", delete_entire_series=True)
-
-    Note:
-        Timezone handling: The system automatically converts all datetimes to the user's local timezone
-        when interacting with the calendar. You can provide datetimes in any timezone (UTC, PST, AEDT, etc.)
-        and they will be converted correctly.
     """
     logger.info(
         f"Attempting to delete event with ID: {event_id}, "

--- a/src/mcp_ical/server.py
+++ b/src/mcp_ical/server.py
@@ -147,51 +147,99 @@ async def create_event(create_event_request: CreateEventRequest) -> str:
 
 
 @mcp.tool()
-async def update_event(event_id: str, update_event_request: UpdateEventRequest) -> str:
-    """Update an existing calendar event.
+async def update_event(
+    event_id: str,
+    update_event_request: UpdateEventRequest,
+    update_future_events: bool = False,
+    occurrence_date: datetime | None = None,
+) -> str:
+    """Update an existing calendar event or a specific occurrence of a recurring event.
+
+    CRITICAL: When updating specific occurrences of recurring events, you MUST use the EXACT datetime
+    from list_events. The datetime should be in the format YYYY-MM-DDTHH:MM:SS in your local timezone
+    WITHOUT a timezone offset (e.g., "2025-11-15T09:00:00", not "2025-11-15T09:00:00+11:00").
+    Do NOT construct dates manually - always copy from list_events output and remove any timezone suffix.
 
     Before using this tool, make sure to:
     1. Ask the user which fields they want to update
-    2. If moving to a different calendar, verify the calendar exists using calendars://list
-    3. If updating time, confirm the new time with the user
-    4. Ask if they want to add/update location if not specified
-    5. Ask if they want to add/update notes if not specified
-    6. Ask if they want to set reminders for the event
+    2. For recurring events, ask if they want to update:
+        - Just one occurrence: provide occurrence_date, update_future_events=False (default)
+        - This occurrence and all future ones: provide occurrence_date, update_future_events=True
+        - All occurrences: don't provide occurrence_date
+    3. If moving to a different calendar, verify the calendar exists using calendars://list
+    4. If updating time, confirm the new time with the user
+    5. Ask if they want to add/update location if not specified
+    6. Ask if they want to add/update notes if not specified
+    7. Ask if they want to set reminders for the event
 
     Args:
-        event_id: Unique identifier of the event to update
-        title: Optional new title
-        start_time: Optional new start time in ISO format
-        end_time: Optional new end time in ISO format
-        notes: Optional new notes/description. Ask user if they want to update notes.
-        location: Optional new location. Ask user if they want to specify/update location.
-        calendar_name: Optional new calendar. Ask user which calendar to use, referencing calendars://list.
-        all_day: Optional all-day flag
-        reminder_offsets: List of minutes before the event to trigger reminders\
-            e.g. [60, 1440] means two reminders, the first 24 hours before the event and the second one hour before.
-        recurrence_rule: Optional recurrence rule for the event. This should be an instance of `RecurrenceRule` with the following fields:
-            - frequency: Frequency of the recurrence (e.g., DAILY, WEEKLY, MONTHLY, YEARLY).
-            - interval: Interval between recurrences (e.g., every 2 weeks).
-            - end_date: Optional end date for the recurrence. If specified, the recurrence will stop on this date.
-            - occurrence_count: Optional number of occurrences. If specified, the recurrence will stop after this many occurrences.
-            - days_of_week: Optional list of weekdays for the event. Use integers to represent days:
-                - Sunday: 1
-                - Monday: 2
-                - Tuesday: 3
-                - Wednesday: 4
-                - Thursday: 5
-                - Friday: 6
-                - Saturday: 7
+        event_id: Unique identifier of the event (master event ID for recurring events)
+        update_event_request: Object containing the fields to update:
+            - title: Optional new title
+            - start_time: Optional new start time in ISO format
+            - end_time: Optional new end time in ISO format
+            - notes: Optional new notes/description. Ask user if they want to update notes.
+            - location: Optional new location. Ask user if they want to specify/update location.
+            - calendar_name: Optional new calendar. Ask user which calendar to use, referencing calendars://list.
+            - all_day: Optional all-day flag
+            - reminder_offsets: List of minutes before the event to trigger reminders\
+                e.g. [60, 1440] means two reminders, the first 24 hours before the event and the second one hour before.
+            - recurrence_rule: Optional recurrence rule for the event. This should be an instance of `RecurrenceRule` with the following fields:
+                - frequency: Frequency of the recurrence (e.g., DAILY, WEEKLY, MONTHLY, YEARLY).
+                - interval: Interval between recurrences (e.g., every 2 weeks).
+                - end_date: Optional end date for the recurrence. If specified, the recurrence will stop on this date.
+                - occurrence_count: Optional number of occurrences. If specified, the recurrence will stop after this many occurrences.
+                - days_of_week: Optional list of weekdays for the event. Use integers to represent days:
+                    - Sunday: 1
+                    - Monday: 2
+                    - Tuesday: 3
+                    - Wednesday: 4
+                    - Thursday: 5
+                    - Friday: 6
+                    - Saturday: 7
+        update_future_events: When True with occurrence_date, updates this occurrence and all future ones.
+                             When False (default) with occurrence_date, updates only this specific occurrence.
+                             Ignored when occurrence_date is None.
+        occurrence_date: The EXACT start time from list_events output in local timezone format.
+                        Required when updating a specific occurrence of a recurring event.
+                        Format: YYYY-MM-DDTHH:MM:SS (e.g., "2025-11-23T14:00:00")
+                        IMPORTANT: Remove any timezone suffix like +11:00 - use local time only.
+                        DO NOT construct this manually - copy from list_events and remove timezone suffix.
 
-    Note: Both `end_date` and `occurrence_count` should not be set simultaneously; choose one or the other, or leave both unset.
+    Usage Examples:
+        - Update non-recurring event: update_event("event-id-123", {...})
+        - Update just one occurrence (default): update_event("event-id-456", {...}, occurrence_date="2025-11-23T14:00:00")
+        - Update from occurrence forward: update_event("event-id-456", {...}, occurrence_date="2025-11-23T14:00:00", update_future_events=True)
+        - Update all occurrences: update_event("event-id-456", {...})
+
+    Note:
+        Both `end_date` and `occurrence_count` should not be set simultaneously; choose one or the other, or leave both unset.
+        The exact datetime format is CRITICAL for occurrence updates. Always use list_events first and copy the exact
+        datetime string, removing any timezone offset (e.g., remove the "+11:00" suffix).
+
+        When update_future_events=True is used with occurrence_date, it creates a separate recurring series
+        from that point forward. Subsequent updates to the master event will not affect this forked series.
     """
+    logger.info(
+        f"Attempting to update event with ID: {event_id}, "
+        f"update_future_events={update_future_events}, "
+        f"occurrence_date={occurrence_date}"
+    )
     try:
         manager = get_calendar_manager()
-        event = manager.update_event(event_id, update_event_request)
+        event = manager.update_event(event_id, update_event_request, update_future_events, occurrence_date)
         if not event:
             return f"Failed to update event. Event with ID {event_id} not found or update failed."
 
-        return f"Successfully updated event: {event.title}"
+        # Build informative success message
+        if occurrence_date and update_future_events:
+            scope = f"occurrence at {occurrence_date.isoformat()} and all future occurrences"
+        elif occurrence_date:
+            scope = f"occurrence at {occurrence_date.isoformat()}"
+        else:
+            scope = "event"
+
+        return f"Successfully updated {scope}: {event.title}"
 
     except Exception as e:
         return f"Error updating event: {str(e)}"
@@ -203,9 +251,10 @@ async def delete_event(
 ) -> str:
     """Delete a calendar event or specific occurrence(s) of a recurring event.
 
-    CRITICAL: When deleting specific occurrences, you MUST use the EXACT datetime from list_events
-    including timezone information. Do NOT construct dates manually - always copy the exact datetime
-    from list_events output to ensure correct matching.
+    CRITICAL: When deleting specific occurrences, you MUST use the EXACT datetime from list_events.
+    The datetime should be in the format YYYY-MM-DDTHH:MM:SS in your local timezone WITHOUT a
+    timezone offset (e.g., "2025-11-15T09:00:00", not "2025-11-15T09:00:00+11:00").
+    Do NOT construct dates manually - always copy from list_events output and remove any timezone suffix.
 
     Before using this tool, make sure to:
     1. Confirm with the user that they want to delete this event
@@ -216,30 +265,30 @@ async def delete_event(
             - Delete the entire series: set delete_entire_series=True (no occurrence_date)
         - Ask which occurrence(s) they want to delete if that isn't very clear
         - Use list_events first to get exact datetimes if you don't have them
-        - Use the EXACT datetime from list_events (including timezone)
+        - Use the EXACT datetime from list_events (remove any timezone suffix)
 
     Args:
         event_id: Unique identifier of the event (master event ID for recurring events)
         delete_entire_series: When True with occurrence_date, deletes that occurrence and all future ones.
                              When True without occurrence_date, deletes all occurrences.
                              When False (default), deletes only the specific occurrence.
-        occurrence_date: The EXACT start time with timezone from list_events output.
+        occurrence_date: The EXACT start time from list_events output in local timezone format.
                         REQUIRED when deleting a specific occurrence.
-                        MUST include timezone information (e.g., "2025-11-23T14:00:00+00:00")
-                        DO NOT construct this manually - copy from list_events output.
+                        Format: YYYY-MM-DDTHH:MM:SS (e.g., "2025-11-23T14:00:00")
+                        IMPORTANT: Remove any timezone suffix like +11:00 - use local time only.
+                        DO NOT construct this manually - copy from list_events and remove timezone suffix.
 
     Usage Examples:
         - Delete non-recurring event: delete_event("event-id-123")
         - Delete one occurrence:
           1. First: list_events to get exact datetime
-          2. Then: delete_event("event-id-456", occurrence_date="2025-11-23T14:00:00+00:00")
-        - Delete from occurrence forward: delete_event("event-id-456", occurrence_date="2025-11-23T14:00:00+00:00", delete_entire_series=True)
+          2. Then: delete_event("event-id-456", occurrence_date="2025-11-23T14:00:00")
+        - Delete from occurrence forward: delete_event("event-id-456", occurrence_date="2025-11-23T14:00:00", delete_entire_series=True)
         - Delete all occurrences: delete_event("event-id-456", delete_entire_series=True)
 
     Note:
-        Timezone information is CRITICAL. If you construct datetimes without timezone info,
-        the deletion may target the wrong occurrence or fail completely. Always use list_events
-        first and copy the exact datetime including timezone offset.
+        The exact datetime format is CRITICAL. Always use list_events first and copy the exact
+        datetime string, removing any timezone offset (e.g., remove the "+11:00" suffix).
     """
     logger.info(
         f"Attempting to delete event with ID: {event_id}, "

--- a/src/mcp_ical/server.py
+++ b/src/mcp_ical/server.py
@@ -72,7 +72,7 @@ async def list_calendars() -> str:
 
 @mcp.tool()
 async def list_events(start_date: datetime, end_date: datetime, calendar_name: str | None = None) -> str:
-    """List calendar events in a date range.
+    """List calendar events in a date range. Returns a compact plaintext summary.
 
     TIMEZONE REQUIRED: start_date and end_date must include an explicit timezone.
     Any of these formats are accepted:
@@ -83,20 +83,21 @@ async def list_events(start_date: datetime, end_date: datetime, calendar_name: s
 
     The start_date should always use the time such that it represents the beginning of that day (00:00:00).
     The end_date should always use the time such that it represents the end of that day (23:59:59).
-    This way, range based searches are always inclusive and can locate all events in that date range.
 
     Args:
-        start_date: Start date in ISO8601 format with explicit timezone (e.g. 2026-03-04T00:00:00+11:00 or 2026-03-04T00:00:00Z).
-        end_date: End date in ISO8601 format with explicit timezone (e.g. 2026-03-04T23:59:59+11:00 or 2026-03-04T23:59:59Z).
+        start_date: Start date in ISO8601 format with explicit timezone.
+        end_date: End date in ISO8601 format with explicit timezone.
         calendar_name: Optional calendar name to filter by
 
-    IMPORTANT — reading results: Each event shows times in TWO formats:
-    - ISO 8601 with UTC offset (e.g. 2026-03-03T22:00:00+00:00) — for machine use only
-    - "Local time: ..." — the pre-converted local time; USE THIS for display and day assignment
+    IMPORTANT — reading results: The output is plaintext, one event per block.
+    Times shown are pre-converted to local time — use them directly for display
+    and day assignment. Each event includes its id for use with update_event or
+    delete_event. To see full details (notes, attendees, URL, etc.) for a
+    specific event, call list_events with a narrow range or inspect via the id.
 
-    Day boundary warning: A UTC timestamp like 2026-03-03T22:00:00+00:00 is actually
-    2026-03-04 in AEDT (UTC+11). Always use the Local time field to determine which
-    calendar day an event belongs to.
+    Cancelled events (status: CANCELLED) are included but flagged. Duplicate
+    all-day events (same title and date from multiple subscribed calendars)
+    are collapsed to a single entry.
     """
     if start_date.tzinfo is None or end_date.tzinfo is None:
         return (
@@ -111,7 +112,19 @@ async def list_events(start_date: datetime, end_date: datetime, calendar_name: s
         if not events:
             return "No events found in the specified date range"
 
-        return "".join([str(event) for event in events])
+        # Deduplicate all-day events with the same title and date
+        # (common with multiple holiday calendar subscriptions)
+        seen_allday: set[tuple[str, str]] = set()
+        deduped: list = []
+        for event in events:
+            if event.all_day:
+                key = (event.title, event.start_time.strftime("%Y-%m-%d"))
+                if key in seen_allday:
+                    continue
+                seen_allday.add(key)
+            deduped.append(event)
+
+        return "\n\n".join(event.to_summary() for event in deduped)
 
     except Exception as e:
         return f"Error listing events: {str(e)}"

--- a/src/mcp_ical/server.py
+++ b/src/mcp_ical/server.py
@@ -74,15 +74,37 @@ async def list_calendars() -> str:
 async def list_events(start_date: datetime, end_date: datetime, calendar_name: str | None = None) -> str:
     """List calendar events in a date range.
 
+    TIMEZONE REQUIRED: start_date and end_date must include an explicit timezone.
+    Any of these formats are accepted:
+      - Local offset:  2026-03-04T00:00:00+11:00
+      - UTC offset:    2026-03-04T00:00:00+00:00
+      - UTC Z suffix:  2026-03-04T00:00:00Z
+    Omitting a timezone entirely will return an error.
+
     The start_date should always use the time such that it represents the beginning of that day (00:00:00).
     The end_date should always use the time such that it represents the end of that day (23:59:59).
     This way, range based searches are always inclusive and can locate all events in that date range.
 
     Args:
-        start_date: Start date in ISO8601 format (YYYY-MM-DDT00:00:00).
-        end_date: Optional end date in ISO8601 format (YYYY-MM-DDT23:59:59).
+        start_date: Start date in ISO8601 format with explicit timezone (e.g. 2026-03-04T00:00:00+11:00 or 2026-03-04T00:00:00Z).
+        end_date: End date in ISO8601 format with explicit timezone (e.g. 2026-03-04T23:59:59+11:00 or 2026-03-04T23:59:59Z).
         calendar_name: Optional calendar name to filter by
+
+    IMPORTANT — reading results: Each event shows times in TWO formats:
+    - ISO 8601 with UTC offset (e.g. 2026-03-03T22:00:00+00:00) — for machine use only
+    - "Local time: ..." — the pre-converted local time; USE THIS for display and day assignment
+
+    Day boundary warning: A UTC timestamp like 2026-03-03T22:00:00+00:00 is actually
+    2026-03-04 in AEDT (UTC+11). Always use the Local time field to determine which
+    calendar day an event belongs to.
     """
+    if start_date.tzinfo is None or end_date.tzinfo is None:
+        return (
+            "Error: start_date and end_date must include an explicit timezone. "
+            "Accepted formats: 2026-03-04T00:00:00+11:00 (local offset), 2026-03-04T00:00:00Z (UTC). "
+            "Naive datetimes are rejected to prevent day-boundary errors. "
+            "Re-submit with a timezone included."
+        )
     try:
         manager = get_calendar_manager()
         events = manager.list_events(start_date, end_date, calendar_name)
@@ -105,15 +127,20 @@ async def create_event(create_event_request: CreateEventRequest) -> str:
     3. Ask if they want to add any notes/description if none provided
     4. Confirm the date and time with the user
     5. Ask if they want to set reminders for the event
+    6. Ask if they want to invite anyone (attendees) to the event
 
     Args:
         title: Event title
-        start_time: Start time in ISO format (YYYY-MM-DDTHH:MM:SS)
-        end_time: End time in ISO format (YYYY-MM-DDTHH:MM:SS)
+        start_time: Start time in ISO format with explicit timezone (e.g. 2026-03-04T09:00:00+11:00 or 2026-03-04T09:00:00Z).
+        end_time: End time in ISO format with explicit timezone (e.g. 2026-03-04T10:00:00+11:00 or 2026-03-04T10:00:00Z).
         notes: Optional event notes/description. Ask user if they want to add notes.
         location: Optional event location. Ask user if they want to specify a location.
         calendar_name: Optional calendar name. Ask user which calendar to use, referencing calendars://list.
         all_day: Whether this is an all-day event
+        attendees: Optional list of email addresses to invite to the event.\
+            Supports both "email@example.com" and "Name <email@example.com>" formats.\
+            The calendar app will send invitations to these attendees.\
+            e.g. ["john@example.com", "Jane Doe <jane@example.com>"]
         reminder_offsets: List of minutes before the event to trigger reminders\
             e.g. [60, 1440] means two reminders, the first 24 hours before the event and the second one hour before.
         recurrence_rule: Optional recurrence rule for the event. This should be an instance of `RecurrenceRule` with the following fields:
@@ -176,6 +203,7 @@ async def update_event(
     5. Ask if they want to add/update location if not specified
     6. Ask if they want to add/update notes if not specified
     7. Ask if they want to set reminders for the event
+    8. Ask if they want to add/update attendees (invitees) for the event
 
     Args:
         event_id: Unique identifier of the event (master event ID for recurring events)
@@ -187,6 +215,10 @@ async def update_event(
             - location: Optional new location. Ask user if they want to specify/update location.
             - calendar_name: Optional new calendar. Ask user which calendar to use, referencing calendars://list.
             - all_day: Optional all-day flag
+            - attendees: Optional list of email addresses to invite to the event.\
+                Supports both "email@example.com" and "Name <email@example.com>" formats.\
+                The calendar app will send invitations to these attendees.\
+                e.g. ["john@example.com", "Jane Doe <jane@example.com>"]
             - reminder_offsets: List of minutes before the event to trigger reminders\
                 e.g. [60, 1440] means two reminders, the first 24 hours before the event and the second one hour before.
             - recurrence_rule: Optional recurrence rule for the event. This should be an instance of `RecurrenceRule` with the following fields:

--- a/tests/test_calendar_manager_integration.py
+++ b/tests/test_calendar_manager_integration.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -72,8 +72,9 @@ def cleanup_events(calendar_manager):
 
 @pytest.fixture
 def test_event_base():
-    """Base event data for testing"""
-    start_time = datetime.now().replace(microsecond=0) + timedelta(days=1)
+    """Base event data for testing - uses timezone-aware datetimes"""
+    # Create timezone-aware datetime in local timezone
+    start_time = datetime.now(timezone.utc).astimezone().replace(microsecond=0) + timedelta(days=1)
     end_time = start_time + timedelta(hours=1)
     return {
         "title": "Test Event",

--- a/tests/test_calendar_manager_integration.py
+++ b/tests/test_calendar_manager_integration.py
@@ -645,3 +645,66 @@ def test_update_recurring_event_all_occurrences(calendar_manager, test_event_bas
 
     # Clean up
     calendar_manager.delete_event(event.identifier, delete_entire_series=True)
+
+
+def test_create_event_with_attendees(calendar_manager, test_event_base, test_calendar, cleanup_events):
+    """Test creating an event with attendees"""
+    # Create event with attendees
+    attendees = ["test1@example.com", "Test User <test2@example.com>"]
+    event = calendar_manager.create_event(
+        CreateEventRequest(
+            title="Meeting with Attendees",
+            start_time=test_event_base["start_time"],
+            end_time=test_event_base["end_time"],
+            notes="Test meeting with invitees",
+            location=test_event_base["location"],
+            calendar_name=test_calendar["name"],
+            attendees=attendees,
+        )
+    )
+    cleanup_events(event.identifier)
+
+    assert event is not None
+    assert event.title == "Meeting with Attendees"
+    assert event.identifier is not None
+
+    # Retrieve the event to verify attendees were added
+    retrieved_event = calendar_manager.find_event_by_id(event.identifier)
+    assert retrieved_event is not None
+
+    # Check that attendees were added (EventKit may format them differently)
+    if retrieved_event.attendees:
+        assert len(retrieved_event.attendees) > 0
+        print(f"Event created with attendees: {retrieved_event.attendees}")
+
+
+def test_update_event_attendees(calendar_manager, test_event_base, test_calendar, cleanup_events):
+    """Test updating attendees on an existing event"""
+    # Create event without attendees
+    event = calendar_manager.create_event(
+        CreateEventRequest(
+            title="Meeting Without Attendees",
+            start_time=test_event_base["start_time"],
+            end_time=test_event_base["end_time"],
+            calendar_name=test_calendar["name"],
+        )
+    )
+    cleanup_events(event.identifier)
+
+    # Update to add attendees
+    attendees = ["attendee1@example.com", "Attendee Two <attendee2@example.com>"]
+    updated_event = calendar_manager.update_event(
+        event.identifier, UpdateEventRequest(attendees=attendees)
+    )
+
+    assert updated_event is not None
+    assert updated_event.identifier == event.identifier
+
+    # Retrieve the event to verify attendees were added
+    retrieved_event = calendar_manager.find_event_by_id(event.identifier)
+    assert retrieved_event is not None
+
+    # Check that attendees were added
+    if retrieved_event.attendees:
+        assert len(retrieved_event.attendees) > 0
+        print(f"Event updated with attendees: {retrieved_event.attendees}")

--- a/tests/test_calendar_manager_integration.py
+++ b/tests/test_calendar_manager_integration.py
@@ -649,7 +649,6 @@ def test_update_recurring_event_all_occurrences(calendar_manager, test_event_bas
 
 def test_create_event_with_attendees(calendar_manager, test_event_base, test_calendar, cleanup_events):
     """Test creating an event with attendees"""
-    # Create event with attendees
     attendees = ["test1@example.com", "Test User <test2@example.com>"]
     event = calendar_manager.create_event(
         CreateEventRequest(
@@ -664,23 +663,22 @@ def test_create_event_with_attendees(calendar_manager, test_event_base, test_cal
     )
     cleanup_events(event.identifier)
 
-    assert event is not None
-    assert event.title == "Meeting with Attendees"
-    assert event.identifier is not None
+    # Give Calendar.app time to sync attendees back to EventKit
+    time.sleep(3)
 
-    # Retrieve the event to verify attendees were added
     retrieved_event = calendar_manager.find_event_by_id(event.identifier)
     assert retrieved_event is not None
+    assert retrieved_event.attendees is not None, "Attendees should not be None"
+    assert len(retrieved_event.attendees) >= 2, f"Expected at least 2 attendees, got {retrieved_event.attendees}"
 
-    # Check that attendees were added (EventKit may format them differently)
-    if retrieved_event.attendees:
-        assert len(retrieved_event.attendees) > 0
-        print(f"Event created with attendees: {retrieved_event.attendees}")
+    # Check emails appear in attendee strings (format is "Name <email>")
+    attendees_str = " ".join(retrieved_event.attendees).lower()
+    assert "test1@example.com" in attendees_str, f"test1@example.com not found in {retrieved_event.attendees}"
+    assert "test2@example.com" in attendees_str, f"test2@example.com not found in {retrieved_event.attendees}"
 
 
 def test_update_event_attendees(calendar_manager, test_event_base, test_calendar, cleanup_events):
     """Test updating attendees on an existing event"""
-    # Create event without attendees
     event = calendar_manager.create_event(
         CreateEventRequest(
             title="Meeting Without Attendees",
@@ -691,20 +689,21 @@ def test_update_event_attendees(calendar_manager, test_event_base, test_calendar
     )
     cleanup_events(event.identifier)
 
-    # Update to add attendees
     attendees = ["attendee1@example.com", "Attendee Two <attendee2@example.com>"]
     updated_event = calendar_manager.update_event(
         event.identifier, UpdateEventRequest(attendees=attendees)
     )
-
     assert updated_event is not None
-    assert updated_event.identifier == event.identifier
 
-    # Retrieve the event to verify attendees were added
+    # Attendees are added via AppleScript (external to EventKit), so reset the store cache
+    time.sleep(3)
+    calendar_manager.event_store.reset()
+
     retrieved_event = calendar_manager.find_event_by_id(event.identifier)
     assert retrieved_event is not None
+    assert retrieved_event.attendees is not None, "Attendees should not be None"
+    assert len(retrieved_event.attendees) >= 2, f"Expected at least 2 attendees, got {retrieved_event.attendees}"
 
-    # Check that attendees were added
-    if retrieved_event.attendees:
-        assert len(retrieved_event.attendees) > 0
-        print(f"Event updated with attendees: {retrieved_event.attendees}")
+    attendees_str = " ".join(retrieved_event.attendees).lower()
+    assert "attendee1@example.com" in attendees_str, f"attendee1@example.com not found in {retrieved_event.attendees}"
+    assert "attendee2@example.com" in attendees_str, f"attendee2@example.com not found in {retrieved_event.attendees}"


### PR DESCRIPTION
This PR addresses the issues identified in #1 by implementing a more robust solution for deleting recurring event occurrences with proper timezone handling.

## Key Improvements

### 1. Timezone-aware occurrence matching
- New `find_event_occurrence()` method with exact datetime matching
- Automatic UTC fallback for naive datetimes (common in LLM-constructed dates)
- Uses ±1 minute search window followed by exact datetime equality check
- **Fixes**: Wrong occurrence deletion issues from #1

### 2. Flexible deletion modes
- **Delete single occurrence**: `occurrence_date` only (default)
- **Delete from occurrence forward**: `occurrence_date` + `delete_entire_series=True`
- **Delete entire series**: `delete_entire_series=True` only
- **Delete non-recurring event**: `event_id` only (unchanged behavior)

### 3. Comprehensive test coverage (as requested in #1)
Added 4 integration tests in `tests/test_calendar_manager_integration.py`:
- `test_delete_non_recurring_event`: Basic deletion case
- `test_delete_recurring_event_entire_series`: Delete all occurrences
- `test_delete_recurring_event_single_occurrence`: Delete one specific occurrence
- `test_delete_recurring_event_from_occurrence_forward`: Delete from occurrence onward
- All tests verify expected behavior with occurrence counts

### 4. Enhanced MCP tool documentation
- **CRITICAL** warnings about using exact datetimes from `list_events`
- Clear usage examples for all deletion scenarios
- Explanation of timezone importance to prevent user errors

## What This Fixes from #1

The original PR had two main issues mentioned in the review:
1. **Wrong occurrence being deleted** → Fixed by exact datetime matching with timezone awareness
2. **Events appearing deleted but not actually removed** → Fixed by proper occurrence lookup before deletion

## Implementation Details

The solution uses EventKit's equality operator for datetime matching after narrowing down candidates with a predicate search. When a naive datetime is provided, it automatically tries UTC interpretation as a fallback (common when Claude constructs times).

Example flow for deleting 3rd occurrence of a daily recurring event:
```python
# 1. User lists events and sees exact datetime
list_events() # Shows: "2025-11-15T14:00:00+00:00"

# 2. Delete using EXACT datetime from list_events
delete_event(
    event_id="ABC123",
    occurrence_date=datetime.fromisoformat("2025-11-15T14:00:00+00:00")
)

# 3. System finds exact match using:
#    - Predicate search: ±1 minute window
#    - Exact match: ekevent.startDate() == target_datetime
```

## Testing

All existing tests pass, plus 4 new integration tests specifically for recurring event deletion scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>